### PR TITLE
Fix Bits instance for GHC 7.6

### DIFF
--- a/Numeric/Natural/Internal.hs
+++ b/Numeric/Natural/Internal.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Numeric.Natural.Internal
@@ -59,6 +60,9 @@ instance Bits Natural where
   shiftR (Natural n) = Natural . shiftR n
   rotateL (Natural n) = Natural . rotateL n
   rotateR (Natural n) = Natural . rotateR n
+#if MIN_VERSION_base(4,6,0)
+  popCount = popCountDefault
+#endif
 
 instance Real Natural where
   toRational (Natural a) = toRational a


### PR DESCRIPTION
This fixes an important warning when building under GHC 7.6 RC1:

```
Numeric/Natural/Internal.hs:44:10: Warning:
    No explicit method or default declaration for `popCount'
    In the instance declaration for `Bits Natural'
```

This is because the `Num` constraint was removed from the `Bits` typeclass, so `popCount` and a couple other methods can no longer have default implementations.  That is, unless the `DefaultSignatures` extension is used; see [ticket 7135](http://hackage.haskell.org/trac/ghc/ticket/7135).
