### PR TITLE
Suggestion: Type classes for semigroup/monoid actions.

### DIFF
--- a/Data/Semigroup/Act.hs
+++ b/Data/Semigroup/Act.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
+module Data.Semigroup.Act where
+
+import Data.Semigroup
+
+-- | Represents an action of semigroup @g@ to set @a@.
+--
+-- Laws: @'Endo' . 'act'@ must be a homomorphism of semigroups.
+class Semigroup g => SemigroupAct g a where
+    act :: g -> (a -> a)
+
+-- | Represents an action of monoid @g@ to set @a@.
+--
+-- Laws: @'Endo' . 'act'@ must be a homomorphism of monoids.
+class (Monoid g, SemigroupAct g a) => MonoidAct g a where
+
+-- | A wrapper for constructing a monoid action from 'Option'.
+newtype OptionSet g a = OptionSet { getOptionSet :: a }
+
+instance (SemigroupAct g a, Semigroup g)
+  => SemigroupAct (Option g) (OptionSet g a) where
+    act (Option Nothing)  x = x
+    act (Option (Just g)) (OptionSet x) = OptionSet $ (act g) x
+instance (SemigroupAct g a, Monoid g)
+  => MonoidAct (Option g) (OptionSet g a) where
+

--- a/semigroups.cabal
+++ b/semigroups.cabal
@@ -45,6 +45,7 @@ library
 
   exposed-modules:
     Data.Semigroup
+    Data.Semigroup.Act
     Data.List.NonEmpty
     Numeric.Natural
     Numeric.Natural.Internal


### PR DESCRIPTION
For my project I found it useful to represent semigroup/monoid actions on a type as a (multi-param) type class. It's basically just a class definition, nothing more, but I felt it could well fit into _semigroups_.

Note that I didn't test it with Hugs (I don't know how to ask cabal to use hugs instead of GHC, for some reason `cabal configure --hugs` didn't compile anything).
