### PR TITLE
Greatly increase Text dependency upper bound

### DIFF
--- a/semigroups.cabal
+++ b/semigroups.cabal
@@ -42,7 +42,7 @@ library
       containers           >= 0.3  && < 0.6,
       hashable             >= 1.1  && < 1.3,
       nats                 >= 0.1  && < 1,
-      text                 >= 0.10 && < 0.12,
+      text                 >= 0.10 && < 2,
       unordered-containers >= 0.2  && < 0.3
 
   hs-source-dirs: src


### PR DESCRIPTION
The `semigroups` package 1.12.x will not build against Text-1.1.0.0, which will be packaged with GHC 7.8 when it is released. I was able to build after increasing the upper bound with GHC 7.7.20140110 and `text-1.1.0.0`. But why increase the bound a little when you can increase it a lot? Presumably nothing `semigroups` depends on in `Text` is likely to be broken unless there's a massive API change, so I've increased the upper bound with that in mind.
