### PR TITLE
If GHC >= 7.8, module is always Thrustworthy due to GHC.Exts

### DIFF
--- a/src/Data/List/NonEmpty.hs
+++ b/src/Data/List/NonEmpty.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE CPP #-}
 
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702
-#ifdef MIN_VERSION_hashable
+#if defined(MIN_VERSION_hashable) || __GLASGOW_HASKELL__ >= 708
 {-# LANGUAGE Trustworthy #-}
 #else
 {-# LANGUAGE Safe #-}

--- a/src/Data/Semigroup.hs
+++ b/src/Data/Semigroup.hs
@@ -8,7 +8,7 @@
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702
 #define LANGUAGE_DefaultSignatures
 {-# LANGUAGE DefaultSignatures #-}
-#ifdef MIN_VERSION_hashable
+#if defined(MIN_VERSION_hashable) || __GLASGOW_HASKELL__ >= 708
 {-# LANGUAGE Trustworthy #-}
 #else
 {-# LANGUAGE Safe #-}


### PR DESCRIPTION
Hi,

I was testing this module with -f-hashable, and I noticed it didn't build on GHC 7.8.2:

```
src/Data/List/NonEmpty.hs:142:1:
    GHC.Exts: Can't be safely imported! The module itself isn't safe.
```

This PR fixes this without further consequences (I hope).

Cheers
