### PR TITLE
Avoid symbol clash with new `Foldable.length`

### DIFF
--- a/src/Data/List/NonEmpty.hs
+++ b/src/Data/List/NonEmpty.hs
@@ -131,7 +131,11 @@ import Control.Monad
 import Data.Data
 #endif
 
+#if MIN_VERSION_base(4,8,0)
+import Data.Foldable hiding (toList, length)
+#else
 import Data.Foldable hiding (toList)
+#endif
 import qualified Data.Foldable as Foldable
 
 #ifdef MIN_VERSION_hashable


### PR DESCRIPTION
Which will be exported starting with `base-4.8.0` if nothing
changes till GHC 7.10
