### PR TITLE
Add support for Generically deriving Semigroup.

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+0.16.2
+------
+* Added `genericMappend` and supporting `GSemigroup` class for generically deriving Semigroup instances.
+
 0.16.1
 ------
 * Added `Semigroup` instances for various Builder constructions in `text` and `bytestring` where available.

--- a/semigroups.cabal
+++ b/semigroups.cabal
@@ -1,6 +1,6 @@
 name:          semigroups
 category:      Algebra, Data, Data Structures, Math
-version:       0.16.1
+version:       0.16.2
 license:       BSD3
 cabal-version: >= 1.10
 license-file:  LICENSE

--- a/src/Data/Semigroup.hs
+++ b/src/Data/Semigroup.hs
@@ -18,6 +18,8 @@
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 704
 #define LANGUAGE_DeriveGeneric
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE FlexibleContexts #-}
 #endif
 
 
@@ -74,6 +76,11 @@ module Data.Semigroup (
   -- * Difference lists of a semigroup
   , diff
   , cycle1
+#ifdef LANGUAGE_DeriveGeneric
+  -- * Generically derived instances
+  , GSemigroup
+  , genericMappend
+#endif
   ) where
 
 import Prelude hiding (foldr1)
@@ -792,4 +799,32 @@ instance Semigroup (IntMap v) where
 instance Ord k => Semigroup (Map k v) where
   (<>) = mappend
   times1p _ a = a
+#endif
+
+#ifdef LANGUAGE_DeriveGeneric
+-- | Generically generate a 'Semigroup' ('<>') operation for any type
+-- implementing 'Generic'. This operation will append two values
+-- by point-wise appending their component fields. It is only defined
+-- for product types.
+genericMappend :: (Generic a, GSemigroup (Rep a)) => a -> a -> a
+genericMappend x y = to (gmappend (from x) (from y))
+
+class GSemigroup f where
+  gmappend :: f p -> f p -> f p
+
+instance GSemigroup U1 where
+  gmappend _ _ = U1
+
+instance GSemigroup V1 where
+  gmappend x y = x `seq` y `seq` error "GSemigroup.V1: gmappend"
+
+instance Semigroup a => GSemigroup (K1 i a) where
+  gmappend (K1 x) (K1 y) = K1 (x <> y)
+
+instance GSemigroup f => GSemigroup (M1 i c f) where
+  gmappend (M1 x) (M1 y) = M1 (gmappend x y)
+
+instance (GSemigroup f, GSemigroup g) => GSemigroup (f :*: g) where
+  gmappend (x1 :*: x2) (y1 :*: y2) = gmappend x1 y1 :*: gmappend x2 y2
+
 #endif


### PR DESCRIPTION
Fixes #26 

If it's decided that picking a bias for sum-types is worse that not supporting them at all I can edit this patch.