### PR TITLE
bump deepseq upper bound for GHC 7.10 compatibility

### DIFF
--- a/semigroups.cabal
+++ b/semigroups.cabal
@@ -95,7 +95,7 @@ library
     build-depends: containers >= 0.3 && < 0.6
 
   if flag(deepseq)
-    build-depends: deepseq >= 1.1 && < 1.4
+    build-depends: deepseq >= 1.1 && < 1.5
 
   if flag(text)
     build-depends: text >= 0.10 && < 2


### PR DESCRIPTION
this makes it build with the current GHC HEAD
