### PR TITLE
MonadPlus/MonadFix instances for NonEmpty, Builder Semigroup instance

### DIFF
--- a/src/Data/List/NonEmpty.hs
+++ b/src/Data/List/NonEmpty.hs
@@ -126,6 +126,11 @@ import Control.DeepSeq (NFData(..))
 #endif
 
 import Control.Monad
+import Control.Monad.Fix
+
+#if MIN_VERSION_base(4,4,0)
+import Control.Monad.Zip (MonadZip(..))
+#endif
 
 #ifdef LANGUAGE_DeriveDataTypeable
 import Data.Data
@@ -189,6 +194,17 @@ instance Exts.IsList (NonEmpty a) where
 #ifdef MIN_VERSION_deepseq
 instance NFData a => NFData (NonEmpty a) where
   rnf (x :| xs) = rnf x `seq` rnf xs
+#endif
+
+instance MonadFix NonEmpty where
+  mfix f = case fix (f . head) of
+             ~(x :| _) -> x :| mfix (tail . f)
+
+#if MIN_VERSION_base(4,4,0)
+instance MonadZip NonEmpty where
+  mzip     = zip
+  mzipWith = zipWith
+  munzip   = unzip
 #endif
 
 length :: NonEmpty a -> Int

--- a/src/Data/Semigroup.hs
+++ b/src/Data/Semigroup.hs
@@ -107,6 +107,7 @@ import Data.ByteString.Lazy as Lazy
 #ifdef MIN_VERSION_text
 import qualified Data.Text as Strict
 import qualified Data.Text.Lazy as Lazy
+import Data.Text.Lazy.Builder
 #endif
 
 #ifdef MIN_VERSION_hashable
@@ -591,6 +592,9 @@ instance Semigroup Strict.Text where
   (<>) = mappend
 
 instance Semigroup Lazy.Text where
+  (<>) = mappend
+
+instance Semigroup Builder where
   (<>) = mappend
 #endif
 


### PR DESCRIPTION
This commit:

* Adds `MonadFix` and `MonadPlus` instances for `NonEmpty`, with similar semantics to lists.
* Adds a `Semigroup` instance for `text` `Builder`s, which are already `Monoid`s.

I considered adding `Semigroup` instances for `bytestring` `Builder`s and `ShortByteString`s, but they are only available in later versions of `bytestring`, and I wasn't sure how you'd want to handle dealing with older versions of `bytestring`.