### PR TITLE
Semigroup instances for ShortByteStrings and Builders

### DIFF
--- a/src/Data/Semigroup.hs
+++ b/src/Data/Semigroup.hs
@@ -102,12 +102,22 @@ import Data.IntMap (IntMap)
 #ifdef MIN_VERSION_bytestring
 import Data.ByteString as Strict
 import Data.ByteString.Lazy as Lazy
+
+# if MIN_VERSION_bytestring(0,10,2)
+import qualified Data.ByteString.Builder as ByteString
+# elif MIN_VERSION_bytestring(0,10,0)
+import qualified Data.ByteString.Lazy.Builder as ByteString
+# endif
+
+# if MIN_VERSION_bytestring(0,10,4)
+import Data.ByteString.Short
+# endif
 #endif
 
 #ifdef MIN_VERSION_text
 import qualified Data.Text as Strict
 import qualified Data.Text.Lazy as Lazy
-import Data.Text.Lazy.Builder
+import qualified Data.Text.Lazy.Builder as Text
 #endif
 
 #ifdef MIN_VERSION_hashable
@@ -585,6 +595,16 @@ instance Semigroup Strict.ByteString where
 
 instance Semigroup Lazy.ByteString where
   (<>) = mappend
+
+# if MIN_VERSION_bytestring(0,10,0)
+instance Semigroup ByteString.Builder where
+  (<>) = mappend
+# endif
+
+# if MIN_VERSION_bytestring(0,10,4)
+instance Semigroup ShortByteString where
+  (<>) = mappend
+# endif
 #endif
 
 #ifdef MIN_VERSION_text
@@ -594,7 +614,7 @@ instance Semigroup Strict.Text where
 instance Semigroup Lazy.Text where
   (<>) = mappend
 
-instance Semigroup Builder where
+instance Semigroup Text.Builder where
   (<>) = mappend
 #endif
 


### PR DESCRIPTION
The follow-up pull request to #42, in which `Semigroup` instances for `ShortByteString`s and `bytestring` `Builders` are provided if built against a recent-enough version of `bytestring`.