### PR TITLE
Define Semigroup Void instance on base-4.8.0.0 and later

### DIFF
--- a/src/Data/Semigroup.hs
+++ b/src/Data/Semigroup.hs
@@ -89,6 +89,7 @@ import Prelude hiding (foldr1)
 
 #if MIN_VERSION_base(4,8,0)
 import Data.Bifunctor
+import Data.Void
 #else
 import Data.Monoid (Monoid(..))
 import Data.Foldable
@@ -318,6 +319,12 @@ instance Semigroup (Monoid.First a) where
 instance Semigroup (Monoid.Last a) where
   a <> Monoid.Last Nothing = a
   _ <> b                   = b
+  times1p _ a = a
+#endif
+
+#if MIN_VERSION_base(4,8,0)
+instance Semigroup Void where
+  a <> _ = a
   times1p _ a = a
 #endif
 


### PR DESCRIPTION
After `Data.Void` was moved to `base` in version 4.8.0.0, there is no longer a `Semigroup Void` instance when using `base-4.8.0.0`. To fix this, I conditionally added a `Semigroup Void` instance (which I [took](http://hackage.haskell.org/package/void-0.7/docs/src/Data-Void.html) from the `void` library) to `semigroups`, similarly to how `hashable` defines instances for `Natural` and `Void`.