### PR TITLE
Semigroup instances for Alt, Proxy, Tagged

### DIFF
--- a/semigroups.cabal
+++ b/semigroups.cabal
@@ -56,6 +56,14 @@ flag deepseq
   default: True
   manual: True
 
+flag tagged
+  description:
+    You can disable the use of the `tagged` package using `-f-tagged`.
+    .
+    Disabling this is an unsupported configuration, but it may be useful for accelerating builds in sandboxes for expert users.
+  default: True
+  manual: True
+
 flag text
   description:
     You can disable the use of the `text` package using `-f-text`.
@@ -100,6 +108,9 @@ library
 
   if flag(deepseq)
     build-depends: deepseq >= 1.1 && < 1.5
+
+  if flag(tagged)
+    build-depends: tagged >= 0.4.4 && < 1
 
   if flag(text)
     build-depends: text >= 0.10 && < 2

--- a/src/Data/Semigroup.hs
+++ b/src/Data/Semigroup.hs
@@ -97,6 +97,9 @@ import Data.Traversable
 #endif
 
 import Data.Monoid (Dual(..),Endo(..),All(..),Any(..),Sum(..),Product(..))
+#if MIN_VERSION_base(4,8,0)
+import Data.Monoid (Alt(..))
+#endif
 
 import Control.Applicative
 import Control.Monad
@@ -130,6 +133,11 @@ import qualified Data.ByteString.Lazy.Builder as ByteString
 # if MIN_VERSION_bytestring(0,10,4)
 import Data.ByteString.Short
 # endif
+#endif
+
+#ifdef MIN_VERSION_tagged
+import Data.Proxy
+import Data.Tagged
 #endif
 
 #ifdef MIN_VERSION_text
@@ -320,6 +328,15 @@ instance Semigroup (Monoid.Last a) where
   a <> Monoid.Last Nothing = a
   _ <> b                   = b
   times1p _ a = a
+#endif
+
+#if MIN_VERSION_base(4,8,0)
+instance Alternative f => Semigroup (Alt f a) where
+# ifdef USE_COERCE
+  (<>) = coerce ((<|>) :: f a -> f a -> f a)
+# else
+  Alt a <> Alt b = Alt (a <|> b)
+# endif
 #endif
 
 #if MIN_VERSION_base(4,8,0)
@@ -893,4 +910,18 @@ instance Semigroup (IntMap v) where
 instance Ord k => Semigroup (Map k v) where
   (<>) = mappend
   times1p _ a = a
+#endif
+
+#ifdef MIN_VERSION_tagged
+instance Semigroup (Proxy s) where
+  _ <> _ = Proxy
+  sconcat _ = Proxy
+  times1p _ _ = Proxy
+
+instance Semigroup a => Semigroup (Tagged s a) where
+# ifdef USE_COERCE
+  (<>) = coerce ((<>) :: a -> a -> a)
+# else
+  Tagged a <> Tagged b = Tagged (a <> b)
+# endif
 #endif

--- a/src/Data/Semigroup.hs
+++ b/src/Data/Semigroup.hs
@@ -135,8 +135,11 @@ import Data.ByteString.Short
 # endif
 #endif
 
-#ifdef MIN_VERSION_tagged
+#if MIN_VERSION_base(4,7,0) || defined(MIN_VERSION_tagged)
 import Data.Proxy
+#endif
+
+#ifdef MIN_VERSION_tagged
 import Data.Tagged
 #endif
 

--- a/src/Data/Semigroup.hs
+++ b/src/Data/Semigroup.hs
@@ -912,12 +912,14 @@ instance Ord k => Semigroup (Map k v) where
   times1p _ a = a
 #endif
 
-#ifdef MIN_VERSION_tagged
+#if MIN_VERSION_base(4,7,0) || defined(MIN_VERSION_tagged)
 instance Semigroup (Proxy s) where
   _ <> _ = Proxy
   sconcat _ = Proxy
   times1p _ _ = Proxy
+#endif
 
+#ifdef MIN_VERSION_tagged
 instance Semigroup a => Semigroup (Tagged s a) where
 # ifdef USE_COERCE
   (<>) = coerce ((<>) :: a -> a -> a)


### PR DESCRIPTION
There are currently some `Monoid` instances in `base` that don't have `Semigroup` counterparts, so I decided to add them:

* `Alt` (introduced to `Data.Monoid` in `base-4.8.0.0`)
* `Proxy` also has a `Monoid` instance in `base-4.8.0.0`. Since adding a `Semigroup (Proxy s)` instance brings in a `tagged` dependency, I added a `Semigroup (Tagged s a)` instance as well.