### PR TITLE
Make Semigroup (Proxy t) instance poly-kinded

### DIFF
--- a/src/Data/Semigroup.hs
+++ b/src/Data/Semigroup.hs
@@ -22,6 +22,10 @@
 {-# LANGUAGE FlexibleContexts #-}
 #endif
 
+#if __GLASGOW_HASKELL__ >= 706
+{-# LANGUAGE PolyKinds #-}
+#endif
+
 #if __GLASGOW_HASKELL__ >= 708
 #define USE_COERCE
 {-# LANGUAGE ScopedTypeVariables #-}


### PR DESCRIPTION
Currently, you can't do something like `(Proxy :: Proxy Maybe) <> (Proxy :: Proxy Maybe)` because the `Semigroup` instance assumes `Proxy`'s type parameter is of kind `*`. Turning on `PolyKinds` on recent-enough GHCs fixes this.