### PR TITLE
Add Semigroup instance for `Data.Binary.Builder.Builder`

### DIFF
--- a/semigroups.cabal
+++ b/semigroups.cabal
@@ -32,6 +32,14 @@ flag hashable
   default: True
   manual: True
 
+flag binary
+  description:
+    You can disable the use of the `binary` package using `-f-binary`.
+    .
+    Disabling this is an unsupported configuration, but it may be useful for accelerating builds in sandboxes for expert users.
+  default: True
+  manual: True
+
 flag bytestring
   description:
     You can disable the use of the `bytestring` package using `-f-bytestring`.
@@ -105,6 +113,9 @@ library
 
     if impl(ghc >= 7.4 && < 7.5)
       build-depends: ghc-prim
+
+    if flag(binary)
+      build-depends: binary
 
     if flag(bytestring)
       build-depends: bytestring >= 0.9 && < 1

--- a/src-ghc7/Data/Semigroup.hs
+++ b/src-ghc7/Data/Semigroup.hs
@@ -126,6 +126,10 @@ import Data.Map (Map)
 import Data.IntMap (IntMap)
 #endif
 
+#ifdef MIN_VERSION_binary
+import qualified Data.Binary.Builder as Builder
+#endif
+
 #ifdef MIN_VERSION_bytestring
 import Data.ByteString as Strict
 import Data.ByteString.Lazy as Lazy
@@ -786,6 +790,11 @@ instance NFData a => NFData (Last a) where
 #endif
 
 -- (==)/XNOR on Bool forms a 'Semigroup', but has no good name
+
+#ifdef MIN_VERSION_binary
+instance Semigroup Builder.Builder where
+  (<>) = mappend
+#endif
 
 #ifdef MIN_VERSION_bytestring
 instance Semigroup Strict.ByteString where


### PR DESCRIPTION
As we can't make `binary` depend on `semigroups` due to cycles,
we should instead have `semigroups` pick up the instance for older GHCs.

See also https://github.com/kolmodin/binary/pull/96