### PR TITLE
Add `sfoldMap`

### DIFF
--- a/src-ghc7/Data/Semigroup.hs
+++ b/src-ghc7/Data/Semigroup.hs
@@ -66,6 +66,7 @@ module Data.Semigroup (
   , stimesIdempotent
   , stimesIdempotentMonoid
   , mtimesDefault
+  , sfoldMap
   -- * Semigroups
   , Min(..)
   , Max(..)
@@ -343,6 +344,11 @@ instance Num a => Semigroup (Product a) where
   Product a <> Product b = Product (a * b)
 #endif
   stimes n (Product a) = Product (a ^ n)
+
+-- | Map each element of the `NonEmpty` list to a semigroup and combine the
+-- results.
+sfoldMap :: Semigroup s => (a -> s) -> NonEmpty a -> s
+sfoldMap f = sconcat . fmap f
 
 -- | This is a valid definition of 'stimes' for a 'Monoid'.
 --


### PR DESCRIPTION
Nonempty list is the free semigroup so it makes sense to include the equivalent of foldMap for it. Practically, it makes working with `Min`, `Max`, averages etc. much easier