### PR TITLE
Don't define Semigroup Binary.Builder instance with binary-0.8.3 and later

### DIFF
--- a/src-ghc7/Data/Semigroup.hs
+++ b/src-ghc7/Data/Semigroup.hs
@@ -127,7 +127,9 @@ import Data.IntMap (IntMap)
 #endif
 
 #ifdef MIN_VERSION_binary
+# if !(MIN_VERSION_binary(0,8,3))
 import qualified Data.Binary.Builder as Builder
+# endif
 #endif
 
 #ifdef MIN_VERSION_bytestring
@@ -796,8 +798,10 @@ instance NFData a => NFData (Last a) where
 -- (==)/XNOR on Bool forms a 'Semigroup', but has no good name
 
 #ifdef MIN_VERSION_binary
+# if !(MIN_VERSION_binary(0,8,3))
 instance Semigroup Builder.Builder where
   (<>) = mappend
+# endif
 #endif
 
 #ifdef MIN_VERSION_bytestring


### PR DESCRIPTION
`binary-0.8.3` changes its `Builder` representation to be a synonym for `bytestring`'s `Builder`, which already has a `Semigroup` instance. To avoid instance conflicts, this PR guards the `Semigroup Binary.Builder` instance with CPP.

Fixes #65.