### PR TITLE
Ensure Semigroup instances for ByteString.Builder and ShortByteString are defined on older GHCs via bytestring-builder

### DIFF
--- a/semigroups.cabal
+++ b/semigroups.cabal
@@ -136,8 +136,8 @@ library
     if flag(bytestring)
       build-depends: bytestring >= 0.9 && < 1
 
-    if flag(bytestring-builder) && impl(ghc < 7.8)
-        build-depends: bytestring-builder >= 0.10.4 && < 1
+    if flag(bytestring-builder)
+      build-depends: bytestring-builder >= 0.10.4 && < 1
 
     if flag(containers)
       build-depends: containers >= 0.3 && < 0.6

--- a/semigroups.cabal
+++ b/semigroups.cabal
@@ -48,6 +48,14 @@ flag bytestring
   default: True
   manual: True
 
+flag bytestring-builder
+  description:
+    You can disable the use of the `bytestring-builder` package using `-f-bytestring-builder`.
+    .
+    Disabling this is an unsupported configuration, but it may be useful for accelerating builds in sandboxes for expert users.
+  default: True
+  manual: True
+
 flag containers
   description:
     You can disable the use of the `containers` package using `-f-containers`.
@@ -84,7 +92,7 @@ flag transformers
   description:
     You can disable the use of the `transformers` package using `-f-transformers`.
     .
-    Disabling this is an unsupported configuration, but it may be useful for accelerating builds in sa    ndboxes for expert users.
+    Disabling this is an unsupported configuration, but it may be useful for accelerating builds in sandboxes for expert users.
   default: True
   manual: True
 
@@ -127,6 +135,9 @@ library
 
     if flag(bytestring)
       build-depends: bytestring >= 0.9 && < 1
+
+    if flag(bytestring-builder) && impl(ghc < 7.8)
+        build-depends: bytestring-builder >= 0.10.4 && < 1
 
     if flag(containers)
       build-depends: containers >= 0.3 && < 0.6

--- a/semigroups.cabal
+++ b/semigroups.cabal
@@ -54,7 +54,7 @@ flag bytestring-builder
     .
     Disabling this is an unsupported configuration, but it may be useful for accelerating builds in sandboxes for expert users.
   default: True
-  manual: True
+  manual: False
 
 flag containers
   description:
@@ -134,10 +134,11 @@ library
       build-depends: binary
 
     if flag(bytestring)
-      build-depends: bytestring >= 0.9 && < 1
-
-    if flag(bytestring-builder)
-      build-depends: bytestring-builder >= 0.10.4 && < 1
+      if flag(bytestring-builder)
+        build-depends: bytestring         >= 0.9    && < 0.10.4,
+                       bytestring-builder >= 0.10.4 && < 1
+      else
+        build-depends: bytestring         >= 0.10.4 && < 1
 
     if flag(containers)
       build-depends: containers >= 0.3 && < 0.6

--- a/src-ghc7/Data/Semigroup.hs
+++ b/src-ghc7/Data/Semigroup.hs
@@ -136,13 +136,13 @@ import qualified Data.Binary.Builder as Builder
 import Data.ByteString as Strict
 import Data.ByteString.Lazy as Lazy
 
-# if MIN_VERSION_bytestring(0,10,2)
+# if MIN_VERSION_bytestring(0,10,2) || defined(MIN_VERSION_bytestring_builder)
 import qualified Data.ByteString.Builder as ByteString
 # elif MIN_VERSION_bytestring(0,10,0)
 import qualified Data.ByteString.Lazy.Builder as ByteString
 # endif
 
-# if MIN_VERSION_bytestring(0,10,4)
+# if MIN_VERSION_bytestring(0,10,4) || defined(MIN_VERSION_bytestring_builder)
 import Data.ByteString.Short
 # endif
 #endif
@@ -811,12 +811,12 @@ instance Semigroup Strict.ByteString where
 instance Semigroup Lazy.ByteString where
   (<>) = mappend
 
-# if MIN_VERSION_bytestring(0,10,0)
+# if MIN_VERSION_bytestring(0,10,0) || defined(MIN_VERSION_bytestring_builder)
 instance Semigroup ByteString.Builder where
   (<>) = mappend
 # endif
 
-# if MIN_VERSION_bytestring(0,10,4)
+# if MIN_VERSION_bytestring(0,10,4) || defined(MIN_VERSION_bytestring_builder)
 instance Semigroup ShortByteString where
   (<>) = mappend
 # endif


### PR DESCRIPTION
`semigroups` defines `Semigroup` instances for `ByteString.Builder` and `ShortByteString`, but only if `bytestring >= 0.10.4` is used. This means that you can't easily use these instances on GHC 7.6 and older, since they ship with an older version of `bytestring`. This is currently [causing problems](https://github.com/bos/aeson/pull/426#issuecomment-225370066) for `aeson` at the moment.

To remedy the situation, it's possibly to use the lightweight `bytestring-builder` compatibility package to ensure that these instances are always defined. I've set it up so that it only installs `bytestring-builder` if absolutely necessary (i.e., if an old GHC version is being used).