### PR TITLE
Turn off bytestring-builder flag by default

### DIFF
--- a/semigroups.cabal
+++ b/semigroups.cabal
@@ -53,7 +53,7 @@ flag bytestring-builder
     Decides whether to use an older version of bytestring along with bytestring-builder or just a newer version of bytestring.
     .
     This flag normally toggles automatically but you can use `-fbytestring-builder` or `-f-bytestring-builder` to explicitly change it.
-  default: True
+  default: False
   manual: False
 
 flag containers


### PR DESCRIPTION
Most stack users will currently run into a dependency resolution
failure similar to the following one when adding `semigroups-0.18.2`
as an extra-dep:

```
In the dependencies for semigroups-0.18.2
     bytestring-0.10.6.0 must match >=0.9 && <0.10.4 (latest applicable is 0.10.2.0)
needed due to stack-1.2.1 -> semigroups-0.18.2
```

This is because stack doesn't attempt to find a "good" flag
configuration automatically, using the default settings instead.

The new default setting will allow users to use semigroups with a
recent version of bytestring without needing to specify an additional
flag setting in their stack.yaml.