### PR TITLE
Define Generic instances back to GHC 7.2

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -2,6 +2,8 @@ next
 ----
 * Add `Semigroup` instance for `IO`, as well as for `Event` and `Lifetime` from
   `GHC.Event`
+* Define `Generic` instances back to GHC 7.2 (previously, they were only back
+  to GHC 7.4)
 
 0.18.2
 ------

--- a/semigroups.cabal
+++ b/semigroups.cabal
@@ -111,7 +111,7 @@ library
 
   build-depends: base >= 2 && < 5
 
-  if impl(ghc >= 7.4)
+  if impl(ghc >= 7.2)
     exposed-modules:
       Data.Semigroup.Generic
 
@@ -127,7 +127,7 @@ library
     if impl(ghc < 7.10)
       build-depends: nats >= 0.1 && < 2
 
-    if impl(ghc >= 7.4 && < 7.5)
+    if impl(ghc >= 7.2 && < 7.5)
       build-depends: ghc-prim
 
     if flag(binary)

--- a/src-ghc7/Data/List/NonEmpty.hs
+++ b/src-ghc7/Data/List/NonEmpty.hs
@@ -13,7 +13,7 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 #endif
 
-#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 704
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702
 #define LANGUAGE_DeriveGeneric
 {-# LANGUAGE DeriveGeneric #-}
 #endif

--- a/src-ghc7/Data/Semigroup.hs
+++ b/src-ghc7/Data/Semigroup.hs
@@ -15,7 +15,7 @@
 #endif
 #endif
 
-#if __GLASGOW_HASKELL__ >= 704
+#if __GLASGOW_HASKELL__ >= 702
 #define LANGUAGE_DeriveGeneric
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE TypeOperators #-}

--- a/src/Data/Semigroup/Generic.hs
+++ b/src/Data/Semigroup/Generic.hs
@@ -1,6 +1,11 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE FlexibleContexts #-}
+#if __GLASGOW_HASKELL__ >= 704
 {-# LANGUAGE Safe #-}
+#else
+{-# LANGUAGE Trustworthy #-}
+#endif
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Semigroup.Generic


### PR DESCRIPTION
Currently, they are only defined back to GHC 7.4, but it's trivial to extend them back to GHC 7.2 (when `GHC.Generics` was first introduced).