### PR TITLE
Add CPP condition for Eta

### DIFF
--- a/src-ghc7/Data/Semigroup.hs
+++ b/src-ghc7/Data/Semigroup.hs
@@ -116,7 +116,7 @@ import Control.Monad
 import Control.Monad.Fix
 import qualified Data.Monoid as Monoid
 import Data.List.NonEmpty
-#if MIN_VERSION_base(4,4,0) && !defined(mingw32_HOST_OS) && !defined(ghcjs_HOST_OS)
+#if MIN_VERSION_base(4,4,0) && !defined(mingw32_HOST_OS) && !defined(ghcjs_HOST_OS) && !defined(ETA_VERSION)
 import GHC.Event
 #endif
 
@@ -1212,7 +1212,7 @@ instance Semigroup a => Semigroup (Tagged s a) where
 instance Semigroup a => Semigroup (IO a) where
     (<>) = liftA2 (<>)
 
-#if !defined(mingw32_HOST_OS) && !defined(ghcjs_HOST_OS)
+#if !defined(mingw32_HOST_OS) && !defined(ghcjs_HOST_OS) && !defined(ETA_VERSION)
 # if MIN_VERSION_base(4,4,0)
 instance Semigroup Event where
     (<>) = mappend


### PR DESCRIPTION
In Eta, we recently got rid of `GHC.Event` and that broke `semigroups-0.18.3` (which was otherwise working until now). I added an extra CPP check to avoid the `GHC.Event` related code and make it compile.