### PR TITLE
Drop GHC-7.2 and GHC-7.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.3.20190425
+# version: 0.3.20190429
 #
 language: c
 dist: xenial
@@ -52,17 +52,11 @@ matrix:
       addons: {"apt":{"sources":["hvr-ghc"],"packages":["ghc-7.6.3","cabal-install-2.4"]}}
     - compiler: ghc-7.4.2
       addons: {"apt":{"sources":["hvr-ghc"],"packages":["ghc-7.4.2","cabal-install-2.4"]}}
-    - compiler: ghc-7.2.2
-      addons: {"apt":{"sources":["hvr-ghc"],"packages":["ghc-7.2.2","cabal-install-2.4"]}}
-    - compiler: ghc-7.0.4
-      addons: {"apt":{"sources":["hvr-ghc"],"packages":["ghc-7.0.4","cabal-install-2.4"]}}
     - compiler: ghc-head
       addons: {"apt":{"sources":["hvr-ghc"],"packages":["ghc-head","cabal-install-head"]}}
       env: GHCHEAD=true
   allow_failures:
     - compiler: ghc-head
-    - compiler: ghc-7.0.4
-    - compiler: ghc-7.2.2
     - compiler: ghc-8.8.1
 before_install:
   - HC=$(echo "/opt/$CC/bin/ghc" | sed 's/-/\//')
@@ -138,7 +132,7 @@ install:
     echo 'packages: "."' >> cabal.project
   - |
     echo "write-ghc-environment-files: always" >> cabal.project
-  - "for pkg in $($HCPKG list --simple-output); do echo $pkg | sed 's/-[^-]*$//' | grep -vE -- '^(semigroups)$' | sed 's/^/constraints: /' | sed 's/$/ installed/' >> cabal.project.local; done"
+  - "for pkg in $($HCPKG list --simple-output); do echo $pkg | sed 's/-[^-]*$//' | (grep -vE -- '^(semigroups)$' || true) | sed 's/^/constraints: /' | sed 's/$/ installed/' >> cabal.project.local; done"
   - cat cabal.project || true
   - cat cabal.project.local || true
   - if [ -f "./configure.ac" ]; then (cd "." && autoreconf -i); fi
@@ -161,7 +155,7 @@ script:
     echo 'packages: "semigroups-*/*.cabal"' >> cabal.project
   - |
     echo "write-ghc-environment-files: always" >> cabal.project
-  - "for pkg in $($HCPKG list --simple-output); do echo $pkg | sed 's/-[^-]*$//' | grep -vE -- '^(semigroups)$' | sed 's/^/constraints: /' | sed 's/$/ installed/' >> cabal.project.local; done"
+  - "for pkg in $($HCPKG list --simple-output); do echo $pkg | sed 's/-[^-]*$//' | (grep -vE -- '^(semigroups)$' || true) | sed 's/^/constraints: /' | sed 's/$/ installed/' >> cabal.project.local; done"
   - cat cabal.project || true
   - cat cabal.project.local || true
   # Building with tests and benchmarks...

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,7 +1,6 @@
 ghc-head:               True
 no-tests-no-benchmarks: False
 unconstrained:          False
-allow-failures:         <7.3
 
 irc-channels: irc.freenode.org#haskell-lens
 

--- a/semigroups.cabal
+++ b/semigroups.cabal
@@ -15,9 +15,7 @@ description:
     In mathematics, a semigroup is an algebraic structure consisting of a set together with an associative binary operation. A semigroup generalizes a monoid in that there might not exist an identity element. It also (originally) generalized a group (a monoid with all inverses) to a type where every element did not have to have an inverse, thus the name semigroup.
 build-type:    Simple
 extra-source-files: .travis.yml README.markdown CHANGELOG.markdown
-tested-with:   GHC == 7.0.4
-             , GHC == 7.2.2
-             , GHC == 7.4.2
+tested-with:   GHC == 7.4.2
              , GHC == 7.6.3
              , GHC == 7.8.4
              , GHC == 7.10.3
@@ -130,9 +128,7 @@ library
 
   build-depends: base >= 2 && < 5
 
-  if impl(ghc >= 7.2)
-    exposed-modules:
-      Data.Semigroup.Generic
+  exposed-modules: Data.Semigroup.Generic
 
   -- legacy configuration
   if impl(ghc < 7.11.20151002)


### PR DESCRIPTION
This is one option...

---

this is fine, people could depend on/allow `semigroups-0.18.5` (even acme-kmett packages) if GHC-7.0 support is needed