### PR TITLE
Allow hashable-1.2.5 and thus GHC-7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.3.20190425
+# version: 0.3.20190429
 #
 language: c
 dist: xenial
@@ -61,8 +61,6 @@ matrix:
       env: GHCHEAD=true
   allow_failures:
     - compiler: ghc-head
-    - compiler: ghc-7.0.4
-    - compiler: ghc-7.2.2
     - compiler: ghc-8.8.1
 before_install:
   - HC=$(echo "/opt/$CC/bin/ghc" | sed 's/-/\//')
@@ -138,7 +136,7 @@ install:
     echo 'packages: "."' >> cabal.project
   - |
     echo "write-ghc-environment-files: always" >> cabal.project
-  - "for pkg in $($HCPKG list --simple-output); do echo $pkg | sed 's/-[^-]*$//' | grep -vE -- '^(semigroups)$' | sed 's/^/constraints: /' | sed 's/$/ installed/' >> cabal.project.local; done"
+  - "for pkg in $($HCPKG list --simple-output); do echo $pkg | sed 's/-[^-]*$//' | (grep -vE -- '^(semigroups)$' || true) | sed 's/^/constraints: /' | sed 's/$/ installed/' >> cabal.project.local; done"
   - cat cabal.project || true
   - cat cabal.project.local || true
   - if [ -f "./configure.ac" ]; then (cd "." && autoreconf -i); fi
@@ -161,7 +159,7 @@ script:
     echo 'packages: "semigroups-*/*.cabal"' >> cabal.project
   - |
     echo "write-ghc-environment-files: always" >> cabal.project
-  - "for pkg in $($HCPKG list --simple-output); do echo $pkg | sed 's/-[^-]*$//' | grep -vE -- '^(semigroups)$' | sed 's/^/constraints: /' | sed 's/$/ installed/' >> cabal.project.local; done"
+  - "for pkg in $($HCPKG list --simple-output); do echo $pkg | sed 's/-[^-]*$//' | (grep -vE -- '^(semigroups)$' || true) | sed 's/^/constraints: /' | sed 's/$/ installed/' >> cabal.project.local; done"
   - cat cabal.project || true
   - cat cabal.project.local || true
   # Building with tests and benchmarks...

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -5,9 +5,9 @@
   that was introduced in `base-4.9`. This is a breaking change for any
   `Semigroup` instances that are defined in tandem with versions of `base`
   older than 4.9.
-* Fix the `Hashable` instance for `Arg` to only hash the first argument,
-  lest equal values have different hashes. For consistency, require
-  `hashable >=1.3` with old GHC / base.
+* Make `Hashable` instance reflect the respective variant as in `hashable`.
+  With `hashable-1.3` , the `Hashable` instance for `Arg` to only hash the
+  first argument, lest equal values have different hashes.
 * Backport the `Lift (NonEmpty a)` instance introduced in
   `template-haskell-2.15.0.0`.
 * `Data.List.NonEmpty` is now unconditionally `Trustworthy`.

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,7 +1,6 @@
 ghc-head:               True
 no-tests-no-benchmarks: False
 unconstrained:          False
-allow-failures:         <7.3
 
 irc-channels: irc.freenode.org#haskell-lens
 

--- a/semigroups.cabal
+++ b/semigroups.cabal
@@ -172,7 +172,7 @@ library
       build-depends: text >= 0.10 && < 2
 
     if flag(hashable)
-      build-depends: hashable >= 1.3  && < 1.4
+      build-depends: hashable >= 1.2.5.0  && < 1.4
 
     if flag(hashable) && flag(unordered-containers)
       build-depends: unordered-containers >= 0.2  && < 0.3

--- a/src-ghc7/Data/Semigroup.hs
+++ b/src-ghc7/Data/Semigroup.hs
@@ -692,8 +692,15 @@ instance (NFData a, NFData b) => NFData (Arg a b) where
 #endif
 
 #ifdef MIN_VERSION_hashable
+#if MIN_VERSION_hashable(1,3,0)
+-- | Instance like defined in @hashable-1.3@
 instance Hashable a => Hashable (Arg a b) where
   hashWithSalt p (Arg a _b) = hashWithSalt p a
+#else
+-- | Instance like defined in @hashable-1.2@
+instance (Hashable a, Hashable b) => Hashable (Arg a b) where
+  hashWithSalt p (Arg a b) = hashWithSalt p a `hashWithSalt` b
+#endif
 #endif
 
 #if MIN_VERSION_base(4,8,0)


### PR DESCRIPTION
... and this another:

---

This is compomise: we still support GHC-7.0, but `Hashable Arg` instance
depends on `hashable` version.

I think this is morally ok, as *observing* difference would require
downstream to depend on `hashable`, thus they can differentiate.
But that's however not entirely true, if one e.g. uses `Arg`
as a key in `HashMap`, yet one wouldn't with old `hashable`
as then `Hashable Arg` and `Eq Arg` disagree, so it probably doesn't
work anyway.