### PR TITLE
Avoid a sneaky Generics-related bug on old GHCs

### DIFF
--- a/src-ghc7/Data/List/NonEmpty.hs
+++ b/src-ghc7/Data/List/NonEmpty.hs
@@ -204,23 +204,23 @@ instance Exts.IsList (NonEmpty a) where
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702 && __GLASGOW_HASKELL__ < 706
 instance Generic1 NonEmpty where
   type Rep1 NonEmpty
-    = D1 D1NonEmpty
-        (C1 C1_0NonEmpty
+    = D1 D1'NonEmpty
+        (C1 C1'_0NonEmpty
              (S1 NoSelector Par1
           :*: S1 NoSelector (Rec1 [])))
   from1 (h :| t) = M1 (M1 (M1 (Par1 h) :*: M1 (Rec1 t)))
   to1 (M1 (M1 (M1 h :*: M1 t))) = unPar1 h :| unRec1 t
 
-instance Datatype D1NonEmpty where
+instance Datatype D1'NonEmpty where
   datatypeName _ = "NonEmpty"
   moduleName   _ = "Data.List.NonEmpty"
 
-instance Constructor C1_0NonEmpty where
+instance Constructor C1'_0NonEmpty where
   conName   _ = ":|"
   conFixity _ = Infix RightAssociative 5
 
-data D1NonEmpty
-data C1_0NonEmpty
+data D1'NonEmpty
+data C1'_0NonEmpty
 #endif
 
 #ifdef MIN_VERSION_deepseq

--- a/src-ghc7/Data/Semigroup.hs
+++ b/src-ghc7/Data/Semigroup.hs
@@ -524,24 +524,24 @@ instance Num a => Num (Min a) where
 
 #if __GLASGOW_HASKELL__ >= 702 && __GLASGOW_HASKELL__ < 706
 instance Generic1 Min where
-  type Rep1 Min = D1 D1Min (C1 C1_0Min (S1 S1_0_0Min Par1))
+  type Rep1 Min = D1 D1'Min (C1 C1'_0Min (S1 S1'_0_0Min Par1))
   from1 (Min x) = M1 (M1 (M1 (Par1 x)))
   to1 (M1 (M1 (M1 x))) = Min (unPar1 x)
 
-instance Datatype D1Min where
+instance Datatype D1'Min where
   datatypeName _ = "Min"
   moduleName   _ = "Data.Semigroup"
 
-instance Constructor C1_0Min where
+instance Constructor C1'_0Min where
   conName     _ = "Min"
   conIsRecord _ = True
 
-instance Selector S1_0_0Min where
+instance Selector S1'_0_0Min where
   selName _ = "getMin"
 
-data D1Min
-data C1_0Min
-data S1_0_0Min
+data D1'Min
+data C1'_0Min
+data S1'_0_0Min
 #endif
 
 newtype Max a = Max { getMax :: a } deriving
@@ -627,24 +627,24 @@ instance Num a => Num (Max a) where
 
 #if __GLASGOW_HASKELL__ >= 702 && __GLASGOW_HASKELL__ < 706
 instance Generic1 Max where
-  type Rep1 Max = D1 D1Max (C1 C1_0Max (S1 S1_0_0Max Par1))
+  type Rep1 Max = D1 D1'Max (C1 C1'_0Max (S1 S1'_0_0Max Par1))
   from1 (Max x) = M1 (M1 (M1 (Par1 x)))
   to1 (M1 (M1 (M1 x))) = Max (unPar1 x)
 
-instance Datatype D1Max where
+instance Datatype D1'Max where
   datatypeName _ = "Max"
   moduleName   _ = "Data.Semigroup"
 
-instance Constructor C1_0Max where
+instance Constructor C1'_0Max where
   conName     _ = "Max"
   conIsRecord _ = True
 
-instance Selector S1_0_0Max where
+instance Selector S1'_0_0Max where
   selName _ = "getMax"
 
-data D1Max
-data C1_0Max
-data S1_0_0Max
+data D1'Max
+data C1'_0Max
+data S1'_0_0Max
 #endif
 
 -- | 'Arg' isn't itself a 'Semigroup' in its own right, but it can be placed inside 'Min' and 'Max'
@@ -711,22 +711,22 @@ instance Bifunctor Arg where
 #if __GLASGOW_HASKELL__ >= 702 && __GLASGOW_HASKELL__ < 706
 instance Generic1 (Arg a) where
   type Rep1 (Arg a)
-    = D1 D1Arg
-        (C1 C1_0Arg
+    = D1 D1'Arg
+        (C1 C1'_0Arg
              (S1 NoSelector (Rec0 a)
           :*: S1 NoSelector Par1))
   from1 (Arg a b) = M1 (M1 (M1 (K1 a) :*: M1 (Par1 b)))
   to1 (M1 (M1 (M1 a :*: M1 b))) = Arg (unK1 a) (unPar1 b)
 
-instance Datatype D1Arg where
+instance Datatype D1'Arg where
   datatypeName _ = "Arg"
   moduleName   _ = "Data.Semigroup"
 
-instance Constructor C1_0Arg where
+instance Constructor C1'_0Arg where
   conName _ = "Arg"
 
-data D1Arg
-data C1_0Arg
+data D1'Arg
+data C1'_0Arg
 #endif
 
 -- | Use @'Option' ('First' a)@ to get the behavior of 'Data.Monoid.First' from @Data.Monoid@.
@@ -797,24 +797,24 @@ instance NFData a => NFData (First a) where
 
 #if __GLASGOW_HASKELL__ >= 702 && __GLASGOW_HASKELL__ < 706
 instance Generic1 First where
-  type Rep1 First = D1 D1First (C1 C1_0First (S1 S1_0_0First Par1))
+  type Rep1 First = D1 D1'First (C1 C1'_0First (S1 S1'_0_0First Par1))
   from1 (First x) = M1 (M1 (M1 (Par1 x)))
   to1 (M1 (M1 (M1 x))) = First (unPar1 x)
 
-instance Datatype D1First where
+instance Datatype D1'First where
   datatypeName _ = "First"
   moduleName   _ = "Data.Semigroup"
 
-instance Constructor C1_0First where
+instance Constructor C1'_0First where
   conName     _ = "First"
   conIsRecord _ = True
 
-instance Selector S1_0_0First where
+instance Selector S1'_0_0First where
   selName _ = "getFirst"
 
-data D1First
-data C1_0First
-data S1_0_0First
+data D1'First
+data C1'_0First
+data S1'_0_0First
 #endif
 
 -- | Use @'Option' ('Last' a)@ to get the behavior of 'Data.Monoid.Last' from @Data.Monoid@
@@ -885,24 +885,24 @@ instance NFData a => NFData (Last a) where
 
 #if __GLASGOW_HASKELL__ >= 702 && __GLASGOW_HASKELL__ < 706
 instance Generic1 Last where
-  type Rep1 Last = D1 D1Last (C1 C1_0Last (S1 S1_0_0Last Par1))
+  type Rep1 Last = D1 D1'Last (C1 C1'_0Last (S1 S1'_0_0Last Par1))
   from1 (Last x) = M1 (M1 (M1 (Par1 x)))
   to1 (M1 (M1 (M1 x))) = Last (unPar1 x)
 
-instance Datatype D1Last where
+instance Datatype D1'Last where
   datatypeName _ = "Last"
   moduleName   _ = "Data.Semigroup"
 
-instance Constructor C1_0Last where
+instance Constructor C1'_0Last where
   conName     _ = "Last"
   conIsRecord _ = True
 
-instance Selector S1_0_0Last where
+instance Selector S1'_0_0Last where
   selName _ = "getLast"
 
-data D1Last
-data C1_0Last
-data S1_0_0Last
+data D1'Last
+data C1'_0Last
+data S1'_0_0Last
 #endif
 
 -- (==)/XNOR on Bool forms a 'Semigroup', but has no good name
@@ -1007,24 +1007,24 @@ instance NFData m => NFData (WrappedMonoid m) where
 
 #if __GLASGOW_HASKELL__ >= 702 && __GLASGOW_HASKELL__ < 706
 instance Generic1 WrappedMonoid where
-  type Rep1 WrappedMonoid = D1 D1WrappedMonoid (C1 C1_0WrappedMonoid (S1 S1_0_0WrappedMonoid Par1))
+  type Rep1 WrappedMonoid = D1 D1'WrappedMonoid (C1 C1'_0WrappedMonoid (S1 S1'_0_0WrappedMonoid Par1))
   from1 (WrapMonoid x) = M1 (M1 (M1 (Par1 x)))
   to1 (M1 (M1 (M1 x))) = WrapMonoid (unPar1 x)
 
-instance Datatype D1WrappedMonoid where
+instance Datatype D1'WrappedMonoid where
   datatypeName _ = "WrappedMonoid"
   moduleName   _ = "Data.Semigroup"
 
-instance Constructor C1_0WrappedMonoid where
+instance Constructor C1'_0WrappedMonoid where
   conName     _ = "WrapMonoid"
   conIsRecord _ = True
 
-instance Selector S1_0_0WrappedMonoid where
+instance Selector S1'_0_0WrappedMonoid where
   selName _ = "unwrapMonoid"
 
-data D1WrappedMonoid
-data C1_0WrappedMonoid
-data S1_0_0WrappedMonoid
+data D1'WrappedMonoid
+data C1'_0WrappedMonoid
+data S1'_0_0WrappedMonoid
 #endif
 
 -- | Repeat a value @n@ times.
@@ -1127,24 +1127,24 @@ instance Semigroup a => Monoid (Option a) where
 
 #if __GLASGOW_HASKELL__ >= 702 && __GLASGOW_HASKELL__ < 706
 instance Generic1 Option where
-  type Rep1 Option = D1 D1Option (C1 C1_0Option (S1 S1_0_0Option (Rec1 Maybe)))
+  type Rep1 Option = D1 D1'Option (C1 C1'_0Option (S1 S1'_0_0Option (Rec1 Maybe)))
   from1 (Option x) = M1 (M1 (M1 (Rec1 x)))
   to1 (M1 (M1 (M1 x))) = Option (unRec1 x)
 
-instance Datatype D1Option where
+instance Datatype D1'Option where
   datatypeName _ = "Option"
   moduleName   _ = "Data.Semigroup"
 
-instance Constructor C1_0Option where
+instance Constructor C1'_0Option where
   conName     _ = "Option"
   conIsRecord _ = True
 
-instance Selector S1_0_0Option where
+instance Selector S1'_0_0Option where
   selName _ = "getOption"
 
-data D1Option
-data C1_0Option
-data S1_0_0Option
+data D1'Option
+data C1'_0Option
+data S1'_0_0Option
 #endif
 
 -- | This lets you use a difference list of a 'Semigroup' as a 'Monoid'.


### PR DESCRIPTION
Due to a bug in old versions of GHC, the names that `semigroups` chooses for its backported `Generic1` instances can clash with the names that happen to be generated under the hood for its derived `Generic` instances. (I somewhat brought this upon myself by copy-pasting the `-ddump-deriv` output of those derived `Generic` instances when creating these `Generic1` instances in the first place, but I didn't realize that this could actually _break_ things.) Here is an example of something which breaks because of this bug:

```hs
#!/usr/bin/env cabal
{- cabal:
build-depends: base, ghc-prim, semigroups >= 0.18.3
-}
module Main where

import Data.Semigroup
import GHC.Generics

main :: IO ()
main = return ()

class Cls a where
  m :: a -> String

instance Cls (First a) where
  m = gm . from

class GCls f where
  gm :: f a -> String

instance Datatype c => GCls (M1 i c f) where
  gm = datatypeName
```

Compiling this with GHC 7.2 or 7.4 will yield the following error:

```
$ cabal new-run Bug.hs -w /opt/ghc/7.4.2/bin/ghc
Resolving dependencies...
Build profile: -w ghc-7.4.2 -O1
In order, the following will be built (use -v for more details):
 - fake-package-0 (exe:script) (first run)
Configuring executable 'script' for fake-package-0..
Preprocessing executable 'script' for fake-package-0..
Building executable 'script' for fake-package-0..
[1 of 1] Compiling Main             ( Main.hs, /tmp/cabal-repl.-20552/dist-newstyle/build/x86_64-linux/ghc-7.4.2/fake-package-0/x/script/build/script/script-tmp/Main.o )

Main.hs:16:7:
    Overlapping instances for Datatype Data.Semigroup.D1First
      arising from a use of `gm'
    Matching instances:
      instance Datatype Data.Semigroup.D1First
        -- Defined in `Data.Semigroup'
      instance Datatype Data.Semigroup.D1First
        -- Defined in `Data.Semigroup'
    In the first argument of `(.)', namely `gm'
    In the expression: gm . from
    In an equation for `m': m = gm . from
```

Yikes.

The workaround is quite simple, thankfully enough—pick literally any other name than `D1First`, as that happens to be the exact name chosen by `deriving Generic`. This patch does this for all such metadata-related data types in `Data.Semigroup` and `Data.List.NonEmpty`.

(Originally noticed by @phadej in phadej/tree-diff#34.)